### PR TITLE
Foundation Code - Generic HTTP Handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/williabk198/timeclock
 
 go 1.24.2
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/errors/doc.go
+++ b/pkg/errors/doc.go
@@ -1,0 +1,2 @@
+// package errors holds the errors that could be thrown by other packages in this project
+package errors

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+type nilValueError struct {
+	varName string
+}
+
+func NewNilValueError(name string) error {
+	return nilValueError{varName: name}
+}
+
+func (nve nilValueError) Error() string {
+	return fmt.Sprintf("%q value was nil", nve.varName)
+}

--- a/pkg/httputil/doc.go
+++ b/pkg/httputil/doc.go
@@ -1,0 +1,2 @@
+// httputil holds utility types and functions that assist with handling HTTP requests
+package httputil

--- a/pkg/httputil/handlers.go
+++ b/pkg/httputil/handlers.go
@@ -1,0 +1,107 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/williabk198/timeclock/pkg/errors"
+)
+
+// RouteHandleBuilder might be a bit of a misnomer since it doesn't have a Build function,
+// but it holds data that could be used across multiple http.Handlers.
+// An example, if your creating a micro-service or just a colletion of related endpoints,
+// then you probably would want to have the same error handling and error response for
+// those endpoints. That is where this data type comes into play.
+type RouteHandleBuilder struct {
+	ErrorEncoder ErrorEncoderFunc
+	ErrorHandler ErrorHandlerFunc
+}
+
+// BuildRouteHandler does what you think, it creates an http.Handler using the provided builder,
+// endpoint handler, encode and decoder. This function isn't attached to RouteHandleBuilder type because
+// of its need for type parameters which are used to hold the types of the request and response data types.
+// In which that would have negatively effected
+func BuildRouteHandler[T, U any](
+	builder RouteHandleBuilder,
+	endpointHandler EndpointLogicFunc[T, U],
+	reqDecoder RequestDecoderFunc[T],
+	respEncoder ResponseEncoderFunc[U],
+) (http.Handler, error) {
+	switch {
+	case builder.ErrorEncoder == nil:
+		return nil, errors.NewNilValueError("builder.ErrorEncoder")
+	case builder.ErrorHandler == nil:
+		return nil, errors.NewNilValueError("builder.ErrorHandler")
+	case endpointHandler == nil:
+		return nil, errors.NewNilValueError("endpointHandler")
+	case reqDecoder == nil:
+		return nil, errors.NewNilValueError("reqDecoder")
+	case respEncoder == nil:
+		return nil, errors.NewNilValueError("respEncoder")
+	}
+
+	return routeHandler[T, U]{
+		endpoint:     endpointHandler,
+		decoder:      reqDecoder,
+		encoder:      respEncoder,
+		errorHandler: builder.ErrorHandler,
+		errorEncoder: builder.ErrorEncoder,
+	}, nil
+}
+
+// routeHandler is heavily inspired by the github.com/go-kit/kit package implementation of its `http.Server` type.
+// The major difference being that it uses generics to represent incoming and outgoing data types instead of using `any`
+type routeHandler[T, U any] struct {
+	endpoint     EndpointLogicFunc[T, U]
+	decoder      RequestDecoderFunc[T]
+	encoder      ResponseEncoderFunc[U]
+	errorEncoder ErrorEncoderFunc
+	errorHandler ErrorHandlerFunc
+}
+
+// ServeHTTP statisfies the http.Handler interface. It executes the RequestDecoderFunc, EndpointLogicFunc, and ResponseEncoderFunc
+// of routeHandler and if any errors an encoutered along the way, they will be handled by the ErrorEncoderFunc and ErrorHandlerFunc
+// that was also provided to the routeHandler.
+func (rh routeHandler[T, U]) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	data, err := rh.decoder(ctx, r)
+	if err != nil {
+		rh.errorHandler(ctx, err)
+		rh.errorEncoder(ctx, err, w)
+		return
+	}
+
+	respData, err := rh.endpoint(ctx, data)
+	if err != nil {
+		rh.errorHandler(ctx, err)
+		rh.errorEncoder(ctx, err, w)
+		return
+	}
+
+	err = rh.encoder(ctx, w, respData)
+	if err != nil {
+		rh.errorHandler(ctx, err)
+		rh.errorEncoder(ctx, err, w)
+		return
+	}
+}
+
+// EndpointLogicFunc represents the core logic to be execuded by an HTTP handler.
+type EndpointLogicFunc[T, U any] func(ctx context.Context, reqData T) (respData U, err error)
+
+// RequestDecoderFunc represents logic that will take in the HTTP request and
+// transforms the data in the request into data that can be consumed by an
+// implementation of a EndpointLogicFunc later.
+type RequestDecoderFunc[T any] func(context.Context, *http.Request) (T, error)
+
+// ResponseEncoderFunc represents the logic that will take in data,
+// presumably from an implementation of EndpointLogicFunc,
+// and transforms, and then sends the transfomed data back to the client.
+type ResponseEncoderFunc[T any] func(context.Context, http.ResponseWriter, T) error
+
+// ErrorEncoderFunc represents the logic that will handle errors and handle a response
+// back to the client related to the given error
+type ErrorEncoderFunc func(context.Context, error, http.ResponseWriter)
+
+// ErrorHandlerFunc represent the logic that will handle errors that occur while handling an HTTP request.
+type ErrorHandlerFunc func(context.Context, error)

--- a/pkg/httputil/handlers_test.go
+++ b/pkg/httputil/handlers_test.go
@@ -1,0 +1,291 @@
+package httputil
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	errTestDecoder  = errors.New("test request decoder error")
+	errTestEndpoint = errors.New("test endpoint logic error")
+	errTestEncoder  = errors.New("test response encoder error")
+)
+
+func TestBuildRouteHandler(t *testing.T) {
+	// To see if the HTTP hander function returned by BuildRouteHandler is correct,
+	// we must also execute the returned HTTP handler and examine what was returned
+	// if we expected a successful result. For test cases where we expect an error,
+	// just simply checking whether the error exists is enough.
+
+	type args[T, U any] struct {
+		builder         RouteHandleBuilder
+		endpointHandler EndpointLogicFunc[T, U]
+		reqDecoder      RequestDecoderFunc[T]
+		respEncoder     ResponseEncoderFunc[U]
+	}
+	type handlerArgs struct {
+		w http.ResponseWriter
+		r *http.Request
+	}
+	type wantResp struct {
+		statusCode int
+		body       []byte
+	}
+
+	tests := []struct {
+		name        string
+		args        args[testReqData, testRespData]
+		handlerArgs handlerArgs
+		wantResp    wantResp
+		assertion   assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Success",
+			args: args[testReqData, testRespData]{
+				builder: RouteHandleBuilder{
+					ErrorEncoder: testErrorEncoder,
+					ErrorHandler: testErrorHandler,
+				},
+				endpointHandler: testEndpointHandler,
+				reqDecoder:      testReqDecoder,
+				respEncoder:     testRespEncoder,
+			},
+			handlerArgs: handlerArgs{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest(http.MethodGet, "/test", strings.NewReader("{\"val\":\"test\"}\n")),
+			},
+			wantResp: wantResp{
+				statusCode: http.StatusOK,
+				body:       []byte("{\"respVal\":\"test\"}\n"),
+			},
+			assertion: assert.NoError,
+		},
+		{
+			// Expect that the function will only return the first error that it encouters.
+			// In this case, it expects that the ErrorEncoder is checked first...
+			name:      "Error, Missing ErrorEncoder",
+			assertion: assert.Error,
+		},
+		{
+			// ... and then the ErrorHandler...
+			name: "Error, Missing ErrorHandler",
+			args: args[testReqData, testRespData]{
+				builder: RouteHandleBuilder{
+					ErrorEncoder: testErrorEncoder,
+				},
+			},
+			assertion: assert.Error,
+		},
+		{
+			// ... and then the EndpointHandlerFunc...
+			name: "Error, Missing EndpointHandler",
+			args: args[testReqData, testRespData]{
+				builder: RouteHandleBuilder{
+					ErrorEncoder: testErrorEncoder,
+					ErrorHandler: testErrorHandler,
+				},
+			},
+			assertion: assert.Error,
+		},
+		{
+			// ... and then the RequestDecoder...
+			name: "Error, Missing RequestDecoder",
+			args: args[testReqData, testRespData]{
+				builder: RouteHandleBuilder{
+					ErrorEncoder: testErrorEncoder,
+					ErrorHandler: testErrorHandler,
+				},
+				endpointHandler: testEndpointHandler,
+			},
+			assertion: assert.Error,
+		},
+		{
+			// ... and then the ResponseEncoder...
+			name: "Error, Missing ResponseEncoder",
+			args: args[testReqData, testRespData]{
+				builder: RouteHandleBuilder{
+					ErrorEncoder: testErrorEncoder,
+					ErrorHandler: testErrorHandler,
+				},
+				endpointHandler: testEndpointHandler,
+				reqDecoder:      testReqDecoder,
+			},
+			assertion: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildRouteHandler(tt.args.builder, tt.args.endpointHandler, tt.args.reqDecoder, tt.args.respEncoder)
+			tt.assertion(t, err)
+			if err != nil {
+				// Do not continue with the test if an error was encountered. Even if one was expected.
+				return
+			}
+
+			got.ServeHTTP(tt.handlerArgs.w, tt.handlerArgs.r)
+			resp := tt.handlerArgs.w.(*httptest.ResponseRecorder)
+
+			gotBody, _ := io.ReadAll(resp.Body)
+
+			assert.Equal(t, tt.wantResp.statusCode, resp.Code)
+			assert.Equal(t, tt.wantResp.body, gotBody)
+		})
+	}
+}
+
+func TestRouteHandler_ServeHTTP(t *testing.T) {
+	type args struct {
+		w http.ResponseWriter
+		r *http.Request
+	}
+	type wantResp struct {
+		statusCode int
+		body       []byte
+	}
+
+	tests := []struct {
+		name         string
+		args         args
+		routeHandler routeHandler[testReqData, testRespData]
+		wantResp     wantResp
+	}{
+		{
+			name: "Success",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest(http.MethodGet, "/test", strings.NewReader("{\"val\":\"testing\"}\n")),
+			},
+			routeHandler: routeHandler[testReqData, testRespData]{
+				endpoint: testEndpointHandler,
+				decoder:  testReqDecoder,
+				encoder:  testRespEncoder,
+			},
+			wantResp: wantResp{
+				statusCode: http.StatusOK,
+				body:       []byte("{\"respVal\":\"testing\"}\n"),
+			},
+		},
+		{
+			name: "Decode Error",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest(http.MethodGet, "/test", nil),
+			},
+			routeHandler: routeHandler[testReqData, testRespData]{
+				decoder: func(ctx context.Context, r *http.Request) (testReqData, error) {
+					return testReqData{}, errTestDecoder
+				},
+				errorEncoder: testErrorEncoder,
+				errorHandler: func(ctx context.Context, err error) {},
+			},
+			wantResp: wantResp{
+				statusCode: http.StatusBadRequest,
+				body:       []byte(errTestDecoder.Error()),
+			},
+		},
+		{
+			name: "Endpoint Logic Error",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest(http.MethodGet, "/test", strings.NewReader("{}\n")),
+			},
+			routeHandler: routeHandler[testReqData, testRespData]{
+				decoder: testReqDecoder,
+				endpoint: func(ctx context.Context, reqData testReqData) (respData testRespData, err error) {
+					err = errTestEndpoint
+					return
+				},
+				errorEncoder: testErrorEncoder,
+				errorHandler: func(ctx context.Context, err error) {},
+			},
+			wantResp: wantResp{
+				statusCode: http.StatusInternalServerError,
+				body:       []byte(errTestEndpoint.Error()),
+			},
+		},
+		{
+			name: "Encoder Error",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest(http.MethodGet, "/test", strings.NewReader("{\"val\":\"testing\"}\n")),
+			},
+			routeHandler: routeHandler[testReqData, testRespData]{
+				decoder:  testReqDecoder,
+				endpoint: testEndpointHandler,
+				encoder: func(ctx context.Context, w http.ResponseWriter, trd testRespData) error {
+					return errTestEncoder
+				},
+				errorEncoder: testErrorEncoder,
+				errorHandler: func(ctx context.Context, err error) {},
+			},
+			wantResp: wantResp{
+				statusCode: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.routeHandler.ServeHTTP(tt.args.w, tt.args.r)
+			resp := tt.args.w.(*httptest.ResponseRecorder)
+
+			assert.Equal(t, tt.wantResp.statusCode, resp.Code)
+			assert.Equal(t, tt.wantResp.body, resp.Body.Bytes())
+		})
+	}
+}
+
+type testReqData struct {
+	Value string `json:"val"`
+}
+
+type testRespData struct {
+	RespValue string `json:"respVal"`
+}
+
+func testReqDecoder(ctx context.Context, r *http.Request) (testReqData, error) {
+	var result testReqData
+
+	if err := json.NewDecoder(r.Body).Decode(&result); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func testRespEncoder(ctx context.Context, w http.ResponseWriter, data testRespData) error {
+	w.WriteHeader(http.StatusOK)
+	return json.NewEncoder(w).Encode(data)
+}
+
+func testErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
+	switch err {
+	case errTestDecoder:
+		w.WriteHeader(http.StatusBadRequest)
+	case errTestEndpoint:
+		w.WriteHeader(http.StatusInternalServerError)
+	case errTestEncoder:
+		w.WriteHeader(http.StatusNoContent)
+		w.Write([]byte{})
+		return
+	}
+	w.Write([]byte(err.Error()))
+}
+
+func testErrorHandler(ctx context.Context, err error) {
+	slog.Default().ErrorContext(ctx, "test error", "error", err.Error())
+}
+
+func testEndpointHandler(ctx context.Context, reqData testReqData) (testRespData, error) {
+	return testRespData{RespValue: reqData.Value}, nil
+}


### PR DESCRIPTION
Added some basic HTTP handlers that will be utilized by the micro-service. This is heavily inspired by the `go-kit/kit` package, but simplified and uses generics that will hopefully cut down on a bit of the boilerplate code that would have been needed if the `go-kit/kit` package was used instead.